### PR TITLE
Fix: upgrade puyapy to 5.6 to fix build issue `critical: KeyError: 0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 algokit==2.9.1
 algokit-utils==4.2.2
-algorand-python==3.1.1
+algorand-python==3.3.0
 algorand-smart-contract-library @ git+https://github.com/Folks-Finance/algorand-smart-contract-library.git@3a82609cde9c93b85b48b72f5d31937f1c295012
-puyapy==5.3.2
+puyapy==5.6.0
 py-algorand-sdk==2.11.1
 setuptools==80.9.0


### PR DESCRIPTION
Building the contracts on Linux with puyapy==5.3.2 resulted in a critical error.
 
Command from build script with increased logging: `algokit compile py ./ntt_contracts --target-avm-version 11 --optimization-level 2 --no-output-source-map --no-output-client --no-output-arc32 --no-output-arc56 --output-teal --out-dir ../specs/teal --log-level debug`
```
-----8<-----
debug: Optimizer: Remove Linear Jumps
debug: Optimizer: Remove Unreachable Blocks
debug: Removing unreachable block: block@7
debug: Optimizer: Repeated Expression Elimination
debug: Traceback (most recent call last):
  File "/home/bit/code/algorand-ntt-contracts/venv/lib/python3.12/site-packages/puya/errors.py", line 45, in log_exceptions
    yield
  File "/home/bit/code/algorand-ntt-contracts/venv/lib/python3.12/site-packages/puyapy/compile.py", line 52, in compile_to_teal
    teal = awst_to_teal(
           ^^^^^^^^^^^^^
  File "/home/bit/code/algorand-ntt-contracts/venv/lib/python3.12/site-packages/puya/compile.py", line 70, in awst_to_teal
    teal = list(_ir_to_teal(log_ctx, context, ir))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bit/code/algorand-ntt-contracts/venv/lib/python3.12/site-packages/puya/compile.py", line 121, in _ir_to_teal
    artifact_ir = transform_ir(artifact_context, artifact_ir)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bit/code/algorand-ntt-contracts/venv/lib/python3.12/site-packages/puya/ir/main.py", line 197, in transform_ir
    transform(context, program)
  File "/home/bit/code/algorand-ntt-contracts/venv/lib/python3.12/site-packages/puya/ir/main.py", line 239, in _optimize_program_ir
    optimize_program_ir(context, program, qualifier=qualifier)
  File "/home/bit/code/algorand-ntt-contracts/venv/lib/python3.12/site-packages/puya/ir/optimize/main.py", line 148, in optimize_program_ir
    if optimizer.optimize(opt_context, subroutine):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bit/code/algorand-ntt-contracts/venv/lib/python3.12/site-packages/puya/ir/optimize/main.py", line 69, in optimize
    did_modify = self._optimize(context, ir)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bit/code/algorand-ntt-contracts/venv/lib/python3.12/site-packages/puya/ir/optimize/repeated_code_elimination.py", line 21, in repeated_expression_elimination
    start, dom_tree = compute_dominator_tree(subroutine)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bit/code/algorand-ntt-contracts/venv/lib/python3.12/site-packages/puya/ir/optimize/repeated_code_elimination.py", line 61, in compute_dominator_tree
    idom_ids.pop(start.id)
KeyError: 0
critical: KeyError: 0
```

(Aside: setting optimization levels to zero also fixes this error, but also results in bloated contracts)

This [has been fixed](https://github.com/algorandfoundation/puya/commit/6f760dc6a859a560b4e4cb776ee209169a9eb036) in a [puyapy 5.5.0](https://github.com/algorandfoundation/puya/releases/tag/v5.5.0)

This PR bumps puyapy and algorand-python to their latest versions. Tests have been confirmed to pass locally (though I did have to extend the timeouts with `npx jest --runInBand --testTimeout=60000`)