### PR TITLE
fix: correct type inconsistency in TrimmedAmountLib test and add pretest script 

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "client": "algokit generate client ./specs/arc56 --output ./specs/client/{contract_name}.client.ts --language typescript",
     "build": "npm run teal && npm run arc56 && npm run client",
     "clean": "rm -rf ./specs",
+    "pretest": "npm run build",
     "test": "jest --runInBand",
     "script": "tsx --env-file=.env"
   },

--- a/tests/library/TrimmedAmountLib.test.ts
+++ b/tests/library/TrimmedAmountLib.test.ts
@@ -77,7 +77,7 @@ describe("TrimmedAmountLib", () => {
       { amt: 123456n, fromDecimals: 8, toDecimals: 6, expected: { amount: 1234n, decimals: 6 } },
       { amt: 123456n, fromDecimals: 12, toDecimals: 10, expected: { amount: 12n, decimals: 8 } },
       // scale down and rounds to zero
-      { amt: 123456n, fromDecimals: 12, toDecimals: 6n, expected: { amount: 0n, decimals: 6 } },
+      { amt: 123456n, fromDecimals: 12, toDecimals: 6, expected: { amount: 0n, decimals: 6 } },
     ])(
       "$amt from $fromDecimals decimals to $toDecimals decimals is $expected",
       async ({ amt, fromDecimals, toDecimals, expected }) => {


### PR DESCRIPTION
## Summary
This PR fixes a type inconsistency bug in the test suite and improves developer experience by adding automatic build step before tests.

## Changes
1. **Fixed type inconsistency in `TrimmedAmountLib.test.ts`**: Changed `toDecimals: 6n` (bigint) to `toDecimals: 6` (number) on line 80 to match all other test cases. The contract expects `UInt8` which is represented as a number in TypeScript, so using `bigint` could cause runtime type errors.

2. **Added `pretest` script**: Automatically runs `npm run build` before tests, ensuring the required generated client files exist. This prevents the common error where tests fail because `specs/client/*.client.ts` files don't exist.

## Testing
- Verified the fix matches the pattern used in all other test cases
- No linting errors introduced
- The `pretest` script will ensure tests have required files before execution

## Impact
- Fixes a potential runtime type error in tests
- Improves developer experience by removing manual build step requirement
